### PR TITLE
Add task creation form and refresh support

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,9 +3,11 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 import TaskList from './TaskList'
+import NewTaskForm from './NewTaskForm'
 
 function App() {
   const [count, setCount] = useState(0)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   return (
     <>
@@ -29,7 +31,8 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
-      <TaskList />
+      <NewTaskForm onTaskCreated={() => setRefreshKey((k) => k + 1)} />
+      <TaskList refreshKey={refreshKey} />
     </>
   )
 }

--- a/frontend/src/NewTaskForm.jsx
+++ b/frontend/src/NewTaskForm.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import axios from 'axios'
+
+function NewTaskForm({ onTaskCreated }) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    axios
+      .post('/api/tasks', { title, description })
+      .then(() => {
+        setTitle('')
+        setDescription('')
+        if (onTaskCreated) {
+          onTaskCreated()
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Title:
+          <input value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Description:
+          <input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+      </div>
+      <button type="submit">Add Task</button>
+    </form>
+  )
+}
+
+export default NewTaskForm
+

--- a/frontend/src/TaskList.jsx
+++ b/frontend/src/TaskList.jsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 
-function TaskList() {
+function TaskList({ refreshKey = 0 }) {
   const [tasks, setTasks] = useState([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let canceled = false
-    axios.get('/api/tasks')
+    setLoading(true)
+    axios
+      .get('/api/tasks')
       .then((res) => {
         if (!canceled) {
           setTasks(res.data)
@@ -24,7 +26,7 @@ function TaskList() {
     return () => {
       canceled = true
     }
-  }, [])
+  }, [refreshKey])
 
   if (loading) {
     return <p>Loading...</p>


### PR DESCRIPTION
## Summary
- add `NewTaskForm` component for submitting new tasks
- refresh task list after task creation
- render form in `App` above the task list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842c5c233ec8331a5ee4beca30a2fdb