### PR TITLE
Implement task delete API and UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -88,5 +88,24 @@ def toggle_task(task_id):
         return jsonify({'error': 'Database error'}), 500
 
 
+@app.route('/api/tasks/<int:task_id>', methods=['DELETE'])
+def delete_task(task_id):
+    """Delete a task and return 204 on success."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.execute(
+            'DELETE FROM tasks WHERE id = ?',
+            (task_id,),
+        )
+        conn.commit()
+        conn.close()
+        if cursor.rowcount == 0:
+            return jsonify({'error': 'Task not found'}), 404
+        return '', 204
+    except sqlite3.Error as exc:
+        app.logger.error('Database error: %s', exc)
+        return jsonify({'error': 'Database error'}), 500
+
+
 if __name__ == '__main__':
     app.run()

--- a/frontend/src/TaskList.jsx
+++ b/frontend/src/TaskList.jsx
@@ -18,6 +18,17 @@ function TaskList({ refreshKey = 0 }) {
       })
   }
 
+  const deleteTask = (id) => {
+    axios
+      .delete(`/api/tasks/${id}`)
+      .then(() => {
+        setTasks((prev) => prev.filter((t) => t.id !== id))
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
   useEffect(() => {
     let canceled = false
     setLoading(true)
@@ -55,6 +66,7 @@ function TaskList({ refreshKey = 0 }) {
             onChange={() => toggleCompleted(task.id)}
           />
           {task.title}
+          <button onClick={() => deleteTask(task.id)}>Delete</button>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- add endpoint to delete tasks in `backend/app.py`
- allow deleting tasks from UI via new button in `TaskList.jsx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842c9b3c81083319c7a44580a66a169