### PR TITLE
Add DELETE task endpoint test

### DIFF
--- a/tests/test_delete_task.py
+++ b/tests/test_delete_task.py
@@ -1,0 +1,51 @@
+import sqlite3
+import importlib.util
+from pathlib import Path
+import pytest
+
+APP_PATH = Path(__file__).resolve().parents[1] / "backend" / "app.py"
+_spec = importlib.util.spec_from_file_location("backend_app", APP_PATH)
+backend_app = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(backend_app)
+
+
+@pytest.fixture()
+def client(tmp_path):
+    """Create a temporary db with one task and return Flask test client."""
+    old_db = backend_app.DATABASE
+    db_path = tmp_path / "tasks.db"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            description TEXT,
+            completed BOOLEAN DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )"""
+    )
+    # insert one task
+    conn.execute(
+        "INSERT INTO tasks (title, description, completed) VALUES (?, ?, ?)",
+        ("task", "desc", False),
+    )
+    conn.commit()
+    conn.close()
+
+    backend_app.DATABASE = str(db_path)
+    backend_app.app.config["TESTING"] = True
+
+    with backend_app.app.test_client() as test_client:
+        yield test_client
+
+    backend_app.DATABASE = old_db
+
+
+def test_delete_task_removes_row(client):
+    response = client.delete("/api/tasks/1")
+    assert response.status_code == 204
+
+    response2 = client.get("/api/tasks")
+    assert response2.status_code == 200
+    assert response2.get_json() == []


### PR DESCRIPTION
## Summary
- add pytest for deleting a task

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842caece8708331bb39a1aaf5fe29ea