### PR TITLE
Add styling for tasks

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,31 @@
 .read-the-docs {
   color: #888;
 }
+
+/* Task list styling */
+.task-list {
+  padding: 0;
+  list-style: none;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.task-item.completed::before {
+  content: '✔';
+  color: green;
+  margin-right: 0.5rem;
+}
+
+.task-title {
+  font-size: 1.2rem;
+  margin-left: 0.5rem;
+}
+
+/* New task form spacing */
+.new-task-form div {
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/NewTaskForm.jsx
+++ b/frontend/src/NewTaskForm.jsx
@@ -22,7 +22,7 @@ function NewTaskForm({ onTaskCreated }) {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} className="new-task-form">
       <div>
         <label>
           Title:

--- a/frontend/src/TaskList.jsx
+++ b/frontend/src/TaskList.jsx
@@ -87,15 +87,18 @@ function TaskList({ refreshKey = 0 }) {
         <button onClick={() => setFilter('active')}>Active</button>
         <button onClick={() => setFilter('completed')}>Completed</button>
       </div>
-      <ul>
+      <ul className="task-list">
         {tasks.map((task) => (
-          <li key={task.id}>
+          <li
+            key={task.id}
+            className={`task-item${task.completed ? ' completed' : ''}`}
+          >
             <input
               type="checkbox"
               checked={!!task.completed}
               onChange={() => toggleCompleted(task.id)}
             />
-            {task.title}
+            <span className="task-title">{task.title}</span>
             <button onClick={() => deleteTask(task.id)}>Delete</button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- style new task form and task list
- show a green checkmark for completed tasks
- space out items and enlarge task titles

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842cd917b6083319f087ea9a2f10c3e