### PR TITLE
Add due date and priority support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,7 +19,7 @@ def get_tasks():
     try:
         conn = get_db_connection()
         rows = conn.execute(
-            'SELECT id, title, description, completed, created_at FROM tasks'
+            'SELECT id, title, description, completed, due_date, priority, created_at FROM tasks'
         ).fetchall()
         conn.close()
         tasks = [dict(row) for row in rows]
@@ -35,6 +35,8 @@ def create_task():
     data = request.get_json() or {}
     title = (data.get('title') or '').strip()
     description = data.get('description')
+    due_date = data.get('due_date')
+    priority = data.get('priority')
 
     if not title:
         return jsonify({'error': 'Title is required'}), 400
@@ -42,13 +44,13 @@ def create_task():
     try:
         conn = get_db_connection()
         cursor = conn.execute(
-            'INSERT INTO tasks (title, description, completed) VALUES (?, ?, ?)',
-            (title, description, False),
+            'INSERT INTO tasks (title, description, completed, due_date, priority) VALUES (?, ?, ?, ?, ?)',
+            (title, description, False, due_date, priority),
         )
         conn.commit()
         task_id = cursor.lastrowid
         row = conn.execute(
-            'SELECT id, title, description, completed, created_at FROM tasks WHERE id = ?',
+            'SELECT id, title, description, completed, due_date, priority, created_at FROM tasks WHERE id = ?',
             (task_id,),
         ).fetchone()
         conn.close()
@@ -60,25 +62,29 @@ def create_task():
 
 @app.route('/api/tasks/<int:task_id>', methods=['PUT'])
 def toggle_task(task_id):
-    """Toggle a task's completed status and return the updated task."""
+    """Toggle a task's completed status and optionally update other fields."""
     try:
         conn = get_db_connection()
         row = conn.execute(
-            'SELECT completed FROM tasks WHERE id = ?',
+            'SELECT completed, due_date, priority FROM tasks WHERE id = ?',
             (task_id,),
         ).fetchone()
         if row is None:
             conn.close()
             return jsonify({'error': 'Task not found'}), 404
 
+        data = request.get_json(silent=True) or {}
         new_completed = not bool(row['completed'])
+        due_date = data.get('due_date', row['due_date'])
+        priority = data.get('priority', row['priority'])
+
         conn.execute(
-            'UPDATE tasks SET completed = ? WHERE id = ?',
-            (new_completed, task_id),
+            'UPDATE tasks SET completed = ?, due_date = ?, priority = ? WHERE id = ?',
+            (new_completed, due_date, priority, task_id),
         )
         conn.commit()
         updated = conn.execute(
-            'SELECT id, title, description, completed, created_at FROM tasks WHERE id = ?',
+            'SELECT id, title, description, completed, due_date, priority, created_at FROM tasks WHERE id = ?',
             (task_id,),
         ).fetchone()
         conn.close()

--- a/frontend/src/NewTaskForm.jsx
+++ b/frontend/src/NewTaskForm.jsx
@@ -4,14 +4,23 @@ import axios from 'axios'
 function NewTaskForm({ onTaskCreated }) {
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [priority, setPriority] = useState('')
 
   const handleSubmit = (e) => {
     e.preventDefault()
     axios
-      .post('/api/tasks', { title, description })
+      .post('/api/tasks', {
+        title,
+        description,
+        due_date: dueDate,
+        priority: priority ? Number(priority) : null,
+      })
       .then(() => {
         setTitle('')
         setDescription('')
+        setDueDate('')
+        setPriority('')
         if (onTaskCreated) {
           onTaskCreated()
         }
@@ -35,6 +44,26 @@ function NewTaskForm({ onTaskCreated }) {
           <input
             value={description}
             onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Due Date:
+          <input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Priority:
+          <input
+            type="number"
+            value={priority}
+            onChange={(e) => setPriority(e.target.value)}
           />
         </label>
       </div>

--- a/frontend/src/TaskList.jsx
+++ b/frontend/src/TaskList.jsx
@@ -99,6 +99,12 @@ function TaskList({ refreshKey = 0 }) {
               onChange={() => toggleCompleted(task.id)}
             />
             <span className="task-title">{task.title}</span>
+            {task.due_date && (
+              <span className="task-due">Due: {task.due_date}</span>
+            )}
+            {task.priority !== null && task.priority !== undefined && (
+              <span className="task-priority">Priority: {task.priority}</span>
+            )}
             <button onClick={() => deleteTask(task.id)}>Delete</button>
           </li>
         ))}

--- a/tests/test_create_task.py
+++ b/tests/test_create_task.py
@@ -23,7 +23,9 @@ def client(tmp_path):
             title TEXT NOT NULL,
             description TEXT,
             completed BOOLEAN DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            due_date TEXT,
+            priority INTEGER
         )"""
     )
     conn.commit()

--- a/tests/test_delete_task.py
+++ b/tests/test_delete_task.py
@@ -23,7 +23,9 @@ def client(tmp_path):
             title TEXT NOT NULL,
             description TEXT,
             completed BOOLEAN DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            due_date TEXT,
+            priority INTEGER
         )"""
     )
     conn.commit()

--- a/tests/test_get_tasks.py
+++ b/tests/test_get_tasks.py
@@ -23,7 +23,9 @@ def client(tmp_path):
             title TEXT NOT NULL,
             description TEXT,
             completed BOOLEAN DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            due_date TEXT,
+            priority INTEGER
         )"""
     )
     conn.commit()

--- a/tests/test_post_tasks.py
+++ b/tests/test_post_tasks.py
@@ -23,7 +23,9 @@ def client(tmp_path):
             title TEXT NOT NULL,
             description TEXT,
             completed BOOLEAN DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            due_date TEXT,
+            priority INTEGER
         )"""
     )
     conn.commit()

--- a/tests/test_put_task.py
+++ b/tests/test_put_task.py
@@ -21,13 +21,15 @@ def client(tmp_path):
             title TEXT NOT NULL,
             description TEXT,
             completed BOOLEAN DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            due_date TEXT,
+            priority INTEGER
         )"""
     )
     # insert one task
     conn.execute(
-        "INSERT INTO tasks (title, description, completed) VALUES (?, ?, ?)",
-        ("task", "desc", False),
+        "INSERT INTO tasks (title, description, completed, due_date, priority) VALUES (?, ?, ?, ?, ?)",
+        ("task", "desc", False, None, None),
     )
     conn.commit()
     conn.close()

--- a/tests/test_toggle_task.py
+++ b/tests/test_toggle_task.py
@@ -22,13 +22,15 @@ def client(tmp_path):
             title TEXT NOT NULL,
             description TEXT,
             completed BOOLEAN DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            due_date TEXT,
+            priority INTEGER
         )"""
     )
     # insert one task
     conn.execute(
-        "INSERT INTO tasks (title, description, completed) VALUES (?, ?, ?)",
-        ("task", "desc", False),
+        "INSERT INTO tasks (title, description, completed, due_date, priority) VALUES (?, ?, ?, ?, ?)",
+        ("task", "desc", False, None, None),
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- extend tasks table columns
- return/accept due_date and priority for tasks
- show due date and priority in the React UI
- update tests for new schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842cee484ec8331b9cde29820b7f9f6